### PR TITLE
updated CDN version in docs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 MIT License
-Copyright (c) 2022 Magensa LLC.
+Copyright (c) 2022-present, Magensa LLC.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ yarn add @magensa/te-connnect @magensa/te-connect-js
   
 or via CDN:
 ```html
-    <script src="https://cdn.magensa.net/te-connect/1.2.2/te-connect.js"></script>
+    <script src="https://cdn.magensa.net/te-connect/1.2.3/te-connect.js"></script>
     <script src="https://cdn.magensa.net/te-connect-js/1.2.0/te-connect-js.js"></script>
 ```
 
@@ -386,7 +386,7 @@ Alternatively - if your project requires a specific version - you may target tha
     <button type="button" id="pay-button">Create Payment</button>
     <button type="button" id="change-styles">Change Styles</button>
 
-    <script src="https://cdn.magensa.net/te-connect/1.2.2/te-connect.js"></script>
+    <script src="https://cdn.magensa.net/te-connect/1.2.3/te-connect.js"></script>
     <script src="https://cdn.magensa.net/te-connect-js/1.2.0/te-connect-js.js"></script>
 
     <script>

--- a/TecPaymentRequestREADME.md
+++ b/TecPaymentRequestREADME.md
@@ -15,7 +15,7 @@ yarn add @magensa/te-connnect @magensa/te-connect-js
 ```
 or via CDN:
 ```html
-    <script src="https://cdn.magensa.net/te-connect/1.2.2/te-connect.js"></script>
+    <script src="https://cdn.magensa.net/te-connect/1.2.3/te-connect.js"></script>
     <script src="https://cdn.magensa.net/te-connect-js/1.2.0/te-connect-js.js"></script>
 ```
 If you would prefer to let the code speak, below we have an [example implementation](#Example-Implementation) for both platforms - along with a [Google Pay complex example](https://github.com/Magensa/te-connect-js/blob/master/TecGooglePayREADME.md#Google-Pay-Example-Implementation) and an [Apple Pay complex example](https://github.com/Magensa/te-connect-js/blob/master/TecApplePayREADME.md#Apple-Pay-Example-Implementation)


### PR DESCRIPTION
New version of @magensa/te-connect has been published to npm.js.
Updated documentation to reflect the new version.