### PR TITLE
docs: apply review enhancements across all README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,29 @@
 
 JavaScript module used to interact with TEConnect.  
 
+## Contents
+- [Getting Started](#getting-started)
+- [Documentation Map](#documentation-map)
+- [Prerequisites](#prerequisites)
+- [Manual Card Entry](#manual-card-entry)
+- [Step-by-step](#step-by-step)
+- [TEConnect Options](#teconnect-options)
+- [TecThreeDs (3DS)](#tecthreedss-3ds-manual-card-entry)
+- [Styles API](#styles-api)
+- [createPayment Return Objects](#createpayment-return-objects)
+- [Example Implementation](#example-implementation)
+- [Example Implementation CDN](#example-implementation-cdn)
+- [TecThreeDs Example](#tecthreedss-example)
+
 # Getting Started
 Via [npmjs](https://www.npmjs.com/package/@magensa/te-connect-js):  
 
-```
+```bash
 npm install @magensa/te-connect @magensa/te-connect-js
 ```
 or
-```
-yarn add @magensa/te-connnect @magensa/te-connect-js
+```bash
+yarn add @magensa/te-connect @magensa/te-connect-js
 ```  
   
 or via CDN:
@@ -19,6 +33,30 @@ or via CDN:
     <script src="https://cdn.magensa.net/te-connect/1.3.4/te-connect.js"></script>
     <script src="https://cdn.magensa.net/te-connect-js/1.3.1/te-connect-js.js"></script>
 ```
+
+## Documentation Map
+
+| You want to... | Go to |
+|---|---|
+| Collect card data with a hosted input form | This file — [Manual Card Entry](#manual-card-entry) |
+| Add 3DS authentication to card entry | This file — [TecThreeDs](#tecthreedss-3ds-manual-card-entry) |
+| Add Apple Pay and/or Google Pay buttons | [TecPaymentRequestREADME.md](./TecPaymentRequestREADME.md) |
+| Deep-configure Apple Pay (listeners, shipping, errors) | [TecApplePayREADME.md](./TecApplePayREADME.md) |
+| Deep-configure Google Pay (callbacks, offers, billing) | [TecGooglePayREADME.md](./TecGooglePayREADME.md) |
+
+## Prerequisites
+
+All TEConnect integrations require a valid [Magensa™](https://magensa.net/) account. Contact the [Magensa Support Team](https://magensa.net/support.html) if you need help creating or configuring an account.
+
+| Integration | What you need |
+|---|---|
+| Manual Card Entry (all integrations) | Magensa™ account + public key |
+| Apple Pay | `appleMerchantId` — granted after Magensa™ Apple Pay onboarding |
+| Google Pay | `googleMerchantId` — obtained from [Google Pay & Wallet Console](https://pay.google.com/business/console) |
+| Google Pay | `gatewayId` — provided by Magensa™ after account creation |
+| Apple Pay, Google Pay | HTTPS domain required in production |
+
+> Apple Pay and Google Pay payment buttons will not render over `http://`. Use a tunneling service (e.g., ngrok) or a local certificate authority (e.g., mkcert) for local development.
 
 # Manual Card Entry
 This document will cover the card Manual Entry utility that TEConnect offers. 3DS Manual Entry is, optionally, available as well; if a valid 3DS API Key is supplied to [the `options` parameter](#TEConnect-Options). 
@@ -116,8 +154,7 @@ demoInit();
 
 4. There are two ways to inject your own styles into the Card Entry fields. One method is static (define styles when mounting), while the other is dynamic (utilize the ```setStyles``` method). The [example implementation](#Example-Implementation) uses both of these methods to demonstrate various ways you can control your custom styles. See the [complete styles API](#Styles-API) for more details.  
 
-5. Optionally, you may hide the ZIP input box, as demonstrated below. Once the input is hidden, the ```billingZip``` parameter becomes optional. If you still wish to provide a ```billingZip``` without rendering the input - you may do so, as demonstrated below (this would hide the ZIP input field, but would still create a payment token with the ```billingZip``` provided in the call).   
-However, if you wish to omit the ```billingZip``` completely, you may do so by hiding the zip input and passing no parameters to the ```createPayment``` function.
+5. By default, a ZIP Code input field is shown and `billingZip` is required. You can hide the ZIP input by passing `{ hideZip: true }` to `createTEConnect`. Once hidden, `billingZip` becomes optional: you may still pass a zip string directly to `createPayment`, or omit it entirely by passing no arguments.
 
 ```index.html```
 ```html
@@ -242,7 +279,7 @@ const exampleThreedsConfig = {
 
 const teInstance = createTEConnect("__publicKeyGoesHere__", { 
     threeds: {
-        threedsApiKey: "__3dsApiKeyGoesHere__",,
+        threedsApiKey: "__3dsApiKeyGoesHere__",
         threedsEnvironment: "sandbox"
     }
 });
@@ -718,7 +755,7 @@ function demoInit() {
 
     teConnect.listenFor("threeds-status", function(threedsStatus) {
         console.log('[3DS Status Listener]:', threedsStatus);
-    }
+    });
 
     teConnect.mountThreeDsCardEntry('example-div', exampleStyles);
 

--- a/TecApplePayREADME.md
+++ b/TecApplePayREADME.md
@@ -1,6 +1,15 @@
 # TEConnect Apple Pay
 This document demonstrates the available options, using Apple Pay via TEConnect.  TEConnect currently offers a Manual Entry form, Apple Pay and Google Pay.  Your app may use one - or all of these platforms to collect a payment token.  The section below explains how opt-in works with TEConnect, for each available platform. The remainder of the document focuses on Apple Pay with TEConnect.
 
+## Contents
+- [Payment Request Opt-In](#payment-request-opt-in)
+- [Apple Pay Payment Request Object](#apple-pay-payment-request-object)
+- [Apple Pay Listeners](#apple-pay-listeners)
+- [Apple Pay Button Options](#apple-pay-button-options)
+- [Apple Pay Example Implementation](#apple-pay-example-implementation)
+- [Apple Pay Error Handling](#apple-pay-error-handling)
+- [Apple Pay User Requirements](#apple-pay-user-requirements)
+
 # Payment Request Opt-In
 ```createTEConnect``` accepts a public key as the first argument. This public key is for [TEConnect Manual Entry](https://github.com/Magensa/te-connect-js#Getting-Started).
 The second argument is the [TEConnect options](https://github.com/Magensa/te-connect-js#TEConnect-Options) object.  
@@ -9,7 +18,7 @@ Providing an ```appleMerchantId``` or a ```googleMerchantId``` to the ```tecPaym
 ```javascript
 const TE_CONNECT = createTEConnect("__publicKeyGoesHere__", {
     tecPaymentRequest: {
-        appleMerchantId: "__tecAppleMerchantId__"
+        appleMerchantId: "__tecAppleMerchantId__",
         googleMerchantId: "__googleMerchantId__",
     }
 });
@@ -29,15 +38,20 @@ const paymentRequestObject = {
 ```
 
 # Apple Pay Payment Request Object
+
+> **Local Development Note:** Apple Pay requires an `https://` domain. The Apple Pay button will not render on `http://localhost`. Use a tunneling service (e.g., ngrok) or a local certificate authority (e.g., mkcert) during development.
+
 This section will specifically address the [ApplePayPaymentRequest object](https://developer.apple.com/documentation/apple_pay_on_the_web/applepaypaymentrequest).
 - [Here is Apple's Documentation about the payment request object](https://developer.apple.com/documentation/apple_pay_on_the_web/applepaypaymentrequest)
 - It is encouraged to read through Apple's documentation for all the options available to you to define your form.
 - Be aware that any inaccuracy in the payment request object will most likely throw a ```TypeError``` without a message. Any errors that come from Apple's javascript rarely have any messages attached to errors.
+- The `applePayVersion` property defaults to `3`. Only change this if you need to opt in to features that require a higher version number — see [Apple's version compatibility table](https://developer.apple.com/documentation/apple_pay_on_the_web/apple_pay_on_the_web_version_history) for details.
+
 Below is an example of a Payment Request object.  This is where your form is defined - so each customer's object will appear differently, depending on the customer's circumstances.
 ```javascript
 const examplePaymentRequestObject = {
-    storeDisplayName: "TEConnect Example Store",
-    applePayVersion: 3, //Default is 3, unless specified
+    storeDisplayName: "TEConnect Example Store", // optional — display name shown in the Apple Pay sheet
+    applePayVersion: 3, // optional — defaults to 3; only change if you need a higher-version feature
     currencyCode: "USD",
     countryCode: "US",
     supportedNetworks: ['visa', 'masterCard', 'amex', 'discover', 'jcb'],
@@ -115,7 +129,7 @@ When listening to the ```confirm-token``` event - there will be two special prop
 - ```completePayment```
     - Call this function within 30 seconds of receiving it - otherwise a timeout error will occur and close the Apple Pay form.
     - There are two possible value types to call this function with - either a string value, or an object:
-        - This function expects either ```"sucess"``` or ```"failure"``` as string options - and will display the chosen completion status on the form.
+        - This function expects either ```"success"``` or ```"failure"``` as string options - and will display the chosen completion status on the form.
         - Optionally, if you've confirmed the user is a [qualified Apple Pay user](#Apple-Pay-User-Requirements) (```canMakePayments``` result has returned ```{ applePay: true }```) you can provide an [Apple Pay Authorization Result](https://developer.apple.com/documentation/apple_pay_on_the_web/applepaypaymentauthorizationresult) for more descriptive error messages.
             - In this case - there will be a ```status``` and an ```errors``` property. The status must be provided in a recognized format ([as demonstrated in the Apple docs](https://developer.apple.com/documentation/apple_pay_on_the_web/applepaypaymentauthorizationresult)).
                 - Since this is an error scenario it's likely that the value needed would be: ```ApplePaySession.STATUS_FAILURE```.
@@ -221,9 +235,11 @@ There are many options and styles available to assist with tailoring the Apple P
 
 | Property Name | Type | Possible Values |
 |:--:|:--:|:--:|
-| ```buttonLanguage``` | ```string``` | [available button languages](https://developer.apple.com/documentation/apple_pay_on_the_web/applepaybuttonlocale) | 
-```buttonType``` | ```string``` | [available button types](https://developer.apple.com/documentation/apple_pay_on_the_web/applepaybuttontype) |
-| ```buttonStyles``` | ```string``` | ```'black'``` ```'white'``` ```'white-outline'``` [available button styles](https://developer.apple.com/documentation/apple_pay_on_the_web/applepaybuttonstyle)  |
+| `buttonLanguage` | `string` | [available button languages](https://developer.apple.com/documentation/apple_pay_on_the_web/applepaybuttonlocale) — not validated, applied directly |
+| `buttonType` | `string` | [available button types](https://developer.apple.com/documentation/apple_pay_on_the_web/applepaybuttontype) — not validated, applied directly |
+| `buttonStyle` | `string` | `'black'` `'white'` `'white-outline'` — validated; unrecognized values fall back to `'black'`. See [available button styles](https://developer.apple.com/documentation/apple_pay_on_the_web/applepaybuttonstyle) |
+
+> **Note:** `buttonLanguage` and `buttonType` are not validated — typos will be silently applied. `buttonStyle` is validated and will default to `'black'` if an unrecognized value is supplied.
 
 <br />
 

--- a/TecGooglePayREADME.md
+++ b/TecGooglePayREADME.md
@@ -1,6 +1,13 @@
 # TEConnect Google Pay
 This document demonstrates the available options, using Google Pay via TEConnect.  TEConnect currently offers a Manual Entry form, 3DS Manual Entry, Apple Pay and Google Pay.  Your app may use one - or all of these platforms to collect a payment token.  The section below explains how opt-in works with TEConnect for Google Pay specifically.
 
+## Contents
+- [Payment Request Opt-In](#payment-request-opt-in)
+- [Google Pay Payment Request Object](#google-pay-payment-request-object)
+- [Google Pay Button Options](#google-pay-button-options)
+- [Google Pay Example Implementation](#google-pay-example-implementation)
+- [Google Pay Error Handling](#google-pay-error-handling)
+
 # Payment Request Opt-In
 ```createTEConnect``` accepts a public key as the first argument. This public key is for [TEConnect Manual Entry](README.md#Getting-Started).
 The second argument is the [TEConnect options](README.md#TEConnect-Options) object.  
@@ -58,7 +65,7 @@ For more information on each property - please see [Google's Documentation](http
 | allowedAuthMethods | ```string[]``` | :x: | ```["PAN_ONLY", "CRYPTOGRAM_3DS"]``` | [More details on ```allowedAuthMethods``` here](https://developers.google.com/pay/api/web/reference/request-objects#CardParameters) |
 | allowedCardNetworks | ```string[]``` | :heavy_check_mark: | N/A  | [More details on ```allowedCardNetworks``` here](https://developers.google.com/pay/api/web/reference/request-objects#CardParameters) |
 | merchantName | ```string``` | :heavy_check_mark: | N/A | ```merchantId``` is provided to the ```createTeConnect``` call. ```merchantName``` is provided in the payment request object. [More info here](https://developers.google.com/pay/api/web/reference/request-objects#MerchantInfo) |
-| gatewayId | ```string``` | :heavy_check_mark: | N/A  | Given by Magensa™ after a successful account creation |
+| gatewayId | ```string``` | :heavy_check_mark: | N/A  | Provided by Magensa™ on account creation. Supplied here in the payment request object. Note: `googleMerchantId` (a separate identifier from Google) is provided to `createTEConnect`, not here — see [TEConnect Options](README.md#TEConnect-Options). |
 | transactionInfo | [```TransactionInfo```](https://developers.google.com/pay/api/web/reference/request-objects#TransactionInfo) | :heavy_check_mark: |  | [More details on all available properties here](https://developers.google.com/pay/api/web/reference/request-objects#TransactionInfo) |
 | callbackIntents | ```string[]``` | :x: | N/A | Declares intents for [paymentDataCallbacks](https://developers.google.com/pay/api/web/reference/request-objects#PaymentDataCallbacks) |
 | paymentDataCallbacks | ```object``` | :x: | N/A | [Callback functions](https://developers.google.com/pay/api/web/reference/request-objects#PaymentDataCallbacks) for dynamic price updates, and user-facing messages via Google Pay form |
@@ -78,7 +85,13 @@ For more information on each property - please see [Google's Documentation](http
 | billingAddressRequired | `boolean` | :x: | false | Set to `true` if you require a billing address [More details here](https://developers.google.com/pay/api/web/reference/request-objects#CardParameters) |
 | billingAddressParameters | `object` | :x: | N/A | The expected fields returned if billingAddressRequired is set to `true`. [More details here](https://developers.google.com/pay/api/web/reference/request-objects#CardParameters) |
 
-
+> **Before deploying to production:**
+> 1. Set `environment: "PRODUCTION"` in your payment request object (default is `"TEST"`).
+> 2. Replace `"__magensa_gateway_id__"` with your live `gatewayId` from Magensa™.
+> 3. Replace `"__googleMerchantId__"` with your verified merchant ID from [Google Pay & Wallet Console](https://pay.google.com/business/console).
+> 4. Ensure your site is served over `https://`.
+>
+> Test tokens generated in `"TEST"` mode cannot be processed by MPPG in production.
 
 # Google Pay Button Options
 Google Pay offers many button options to tailor the Google Pay Button to the applications theme. [Here are Google's Brand Guidelines](https://developers.google.com/pay/api/web/guides/brand-guidelines) that explain how the button may be styled appropriately.
@@ -101,7 +114,7 @@ Below is a table of available properties, and after that are examples.  Feed the
 | buttonLocale | ```string``` | See Google's [ButtonOptions](https://developers.google.com/pay/api/web/reference/request-objects#ButtonOptions) |
 | buttonSizeMode | ```string``` | See Google's [ButtonOptions](https://developers.google.com/pay/api/web/reference/request-objects#ButtonOptions) |
 | buttonRadius | `number` | See Google's [ButtonOptions](https://developers.google.com/pay/api/web/reference/request-objects#ButtonOptions) |
-| buttonRootNode | ```HTMLDocument or ShadowRoot``` | See Google's [ButtonOptions](https://developers.google.com/pay/api/web/reference/request-objects#ButtonOptions) |
+| buttonRootNode | ```HTMLDocument or ShadowRoot``` | See Google's [ButtonOptions](https://developers.google.com/pay/api/web/reference/request-objects#ButtonOptions). Only needed when rendering the button inside a Shadow DOM (e.g., a Web Component). In standard DOM contexts, omit this property. |
 
 ```javascript
 const exampleGoogleButtonOptions = {
@@ -125,7 +138,7 @@ function demoInit() {
         tecPaymentRequest: { googleMerchantId: "__tecGoogleMerchantId__" } 
     });
 
-    var teConnect = new TeConnectJs(teInstance);
+    var teConnect = new TeConnectJs(teConnectInstance);
 
     var tecPrInterface = teConnect.createTecPaymentRequest(googlePaymentRequestObject);
 
@@ -363,7 +376,7 @@ function demoInit() {
         tecPaymentRequest: { googleMerchantId: "__tecGoogleMerchantId__" } 
     });
 
-    var teConnect = new TeConnectJs(teInstance);
+    var teConnect = new TeConnectJs(teConnectInstance);
 
     var tecPrInterface = teConnect.createTecPaymentRequest(googlePaymentRequestObject);
 
@@ -373,7 +386,10 @@ function demoInit() {
     });
 
     /*
-    Note that because we have registered an `onPaymentAuthorized` callback in the payment request object, the listener below becomes optional for Google Pay:
+    Because onPaymentAuthorized is registered in paymentDataCallbacks above, the token is
+    delivered to that callback before the 'confirm-token' event fires. In this pattern,
+    listening for 'confirm-token' is optional for Google Pay.
+    For a simpler integration without paymentDataCallbacks, see TecPaymentRequestREADME.md.
 
     tecPrInterface.listenFor('confirm-token', tokenResp => {
         const { tokenDetails, completePayment, error } = tokenResp;

--- a/TecPaymentRequestREADME.md
+++ b/TecPaymentRequestREADME.md
@@ -1,17 +1,33 @@
 # TEConnect Payment Request JS
 [![npm version](https://img.shields.io/npm/v/@magensa/te-connect-js.svg?style=for-the-badge)](https://www.npmjs.com/package/@magensa/te-connect-js "@magensa/te-connect-js npm.js")  
-JavaScript module for use with Apple Pay via Token Exchange Connect
+JavaScript module for use with Apple Pay and Google Pay via Token Exchange Connect
+
+> Use this document for a minimal dual-platform (Apple + Google) integration.
+> For platform-specific features — shipping callbacks, button customization,
+> error handling — see [TecApplePayREADME.md](./TecApplePayREADME.md) and
+> [TecGooglePayREADME.md](./TecGooglePayREADME.md).
+
+## Contents
+- [Payment Request Platforms](#payment-request-platforms)
+- [Getting Started](#getting-started)
+- [Step-by-step](#step-by-step)
+- [Payment Request Object](#payment-request-object)
+- [Token Exchange Connect Payment Request Interface](#token-exchange-connect-payment-request-interface)
+- [Payment Request Event Handlers](#payment-request-event-handlers)
+- [Payment Request Button Options](#payment-request-button-options)
+- [Example Implementation](#example-implementation)
+- [Payment Request Error Handling](#payment-request-error-handling)
 
 # Payment Request Platforms
 TEConnect currently offers two payment request platforms to create payment tokens: [Apple Pay](https://github.com/Magensa/te-connect-js/blob/master/TecApplePayREADME.md), and [Google Pay](https://github.com/Magensa/te-connect-js/blob/master/TecGooglePayREADME.md).  The payment tokens are processed via [Magensa's Payment Protection Gateway](https://svc1.magensa.net/MPPGv4/MPPGv4Service.svc) (MPPG). To that end - there are many configurable options exposed when using [Apple Pay](https://github.com/Magensa/te-connect-js/blob/master/TecApplePayREADME.md), and [Google Pay](https://github.com/Magensa/te-connect-js/blob/master/TecGooglePayREADME.md) via TEConnect.  This document will focus on a very simple implementation using both platforms. If you are interested in a more customized experience for your users, using [Apple Pay](https://github.com/Magensa/te-connect-js/blob/master/TecApplePayREADME.md), and/or [Google Pay](https://github.com/Magensa/te-connect-js/blob/master/TecGooglePayREADME.md) - check out the [TecApplePayREADME.md](https://github.com/Magensa/te-connect-js/blob/master/TecApplePayREADME.md), and/or [TecGooglePayREADME](https://github.com/Magensa/te-connect-js/blob/master/TecGooglePayREADME.md) which will cover more specific configuration for each - as well as links to Apple/Google's documentation, respectively.
 
 # Getting Started
-```
+```bash
 npm install @magensa/te-connect @magensa/te-connect-js
 ```
 or
-```
-yarn add @magensa/te-connnect @magensa/te-connect-js
+```bash
+yarn add @magensa/te-connect @magensa/te-connect-js
 ```
 or via CDN:
 ```html
@@ -228,7 +244,9 @@ const teConnectPaymentRequestObject = {
 The Token Exchange Connect Payment Request Interface (referred to as the ```tecPrInterface```) is the interface needed to interact, and respond to user's interactions on the Payment Request Form.
 
 ## Create Payment Request Interface
-The ```createTecPaymentRequest``` function is property of the ```TeConnectJs``` class, after it's been instanted. Feed this function a [payment request object](#Payment-Request-Object) and it returns the ```tecPrInterface```.
+The `createTecPaymentRequest` function is a property of the `TeConnectJs` class, after it has been instantiated. Feed this function a [payment request object](#Payment-Request-Object) and it returns the `tecPrInterface`.
+
+> `createTecPaymentRequest` returns an interface object. This document refers to that object as `tecPrInterface` throughout — you can name it anything in your application.
 
 ## Interface Methods
 ### ```canMakePayments```
@@ -271,8 +289,32 @@ type CanMakePaymentsResult = {
 ```
 
 ### ```updatePaymentRequest```
-This function is only useful _before_ the user has hit the Apple Pay button.  If you have [created a payment request interface](#Create-Payment-Request-Interface), using a [payment request object](#Payment-Request-Object) - but wish to update that object before the user hits the button and renders the payment request form - you may call this function to do so.  Be aware that this function is a __full update__, so the object will completely replace the previous payment request object supplied.
-- It's not necessary to update your object inside of [payment request listeners](#Payment-Request-Event-Handlers). Any response in your completion functions will update the form dynamically.
+This function is only useful _before_ the user has hit the payment button. If you have [created a payment request interface](#Create-Payment-Request-Interface) using a [payment request object](#Payment-Request-Object) but wish to update that object before the user opens the payment form, call this function. Be aware that this function is a **full update** — the new object completely replaces the previous one.
+
+- It is not necessary to call `updatePaymentRequest` inside [payment request listeners](#Payment-Request-Event-Handlers). Response objects passed to listener completion functions update the form dynamically.
+
+```javascript
+// Example: update the transaction total before the user taps the button
+tecPrInterface.updatePaymentRequest({
+    applePay: {
+        ...existingApplePayRequestObject,
+        total: {
+            label: "Updated Total",
+            amount: "2.50",
+            type: "final"
+        }
+    },
+    googlePay: {
+        ...existingGooglePayRequestObject,
+        transactionInfo: {
+            totalPriceStatus: "FINAL",
+            totalPrice: "2.50",
+            currencyCode: "USD",
+            countryCode: "US"
+        }
+    }
+});
+```
 
 
 ### ```listenFor```


### PR DESCRIPTION
## Summary

Applies recommendations from a prior documentation review of this repo, plus quality improvements discovered during implementation. All four root-level README files were updated. No code changes — docs only.

## Changes by File

### `README.md`
- Added `## Contents` TOC with anchor links
- Added `## Documentation Map` table routing readers to the three companion docs
- Added `## Prerequisites` table covering account/key requirements per integration, with HTTPS callout
- Fixed `@magensa/te-connnect` typo (triple-n) in install snippet
- Added `bash` language tag to npm/yarn install fences
- Rewrote inverted `billingZip` step 5 — ZIP is shown by default and hidden via `{ hideZip: true }`
- Fixed double-comma syntax error in 3DS opt-in snippet
- Fixed missing closing `)` on `listenFor(...)` in TecThreeDs example

### `TecPaymentRequestREADME.md`
- Added top-of-file navigation callout
- Added `## Contents` TOC
- Fixed `@magensa/te-connnect` typo
- Added `bash` language tags to install fences
- Added clarifying note that `tecPrInterface` is a naming convention, not a required identifier
- Added missing code example for `updatePaymentRequest` (was prose-only)
- Corrected subtitle from "Apple Pay only" to "Apple Pay and Google Pay"

### `TecApplePayREADME.md`
- Added `## Contents` TOC
- Fixed missing trailing comma in opt-in snippet
- Added local-development HTTPS callout above the payment request object section
- Documented `applePayVersion` default (3) and when to override
- Fixed `buttonStyles` → `buttonStyle` (singular) in Button Options table — matches the canonical defaults object and the property that is actually validated
- Added validation note: `buttonLanguage`/`buttonType` not validated; `buttonStyle` falls back to `'black'`
- Inline comments clarifying `storeDisplayName` and `applePayVersion` are optional
- Fixed `"sucess"` → `"success"` typo in `completePayment` documentation

### `TecGooglePayREADME.md`
- Added `## Contents` TOC
- Clarified `gatewayId` belongs in the payment request object (not `createTEConnect`) and explained the Magensa-issued vs Google-issued identifier split
- Added production-deployment callout covering `environment`, live IDs, and HTTPS
- Explained `buttonRootNode` is only needed for Shadow DOM / Web Components contexts
- Expanded the commented-out `confirm-token` block with explanation of why it's optional when `onPaymentAuthorized` is used
- Fixed ReferenceError bug in two examples: variable was declared as `teConnectInstance` but referenced as `teInstance` in the `new TeConnectJs(...)` call

## Items Intentionally Not Addressed

The original review report was titled `te-connect-react-docs-review.md` and contained recommendations specific to the React SDK (`te-connect-react`). The following items did not apply to this vanilla JS repo and were skipped:

- `ReactDOM.render` deprecation, `useEffect` dependency arrays, `useTecPaymentsRequest` naming — React-only; not present here.
- "Extract complex example into `consts.js` + `exampleApp.js`" — meaningful refactor; deferred for a separate PR with maintainer sign-off rather than bundled here.
- "Consolidate installation into one canonical location" — the three install blocks are short and serve as natural entry points for each doc; typo fixes addressed the actual harm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)